### PR TITLE
add support for Date values

### DIFF
--- a/jsonflatter.js
+++ b/jsonflatter.js
@@ -10,12 +10,12 @@ function flatJson_internal(prefix, json){
       prefix += internal_options.separator;
    }
    underscore.each( Object.keys(json), function(elem){
-      if( typeof json[elem] === 'object' && json[elem]!==null ) {
+      if( typeof json[elem] === 'object' && json[elem]!==null && !underscore.isDate(json[elem]) ) {
          underscore.extend(rst, flatJson_internal(prefix+elem, json[elem]));
       }
       else {
          if(internal_options.callback) {
-            internal_options.callback(prefix+elem, json[elem])
+            internal_options.callback(prefix+elem, json[elem]);
          }
          rst[prefix+elem] = json[elem];
       }
@@ -28,5 +28,5 @@ exports = module.exports = {
       underscore.extend(internal_options, options);
       return flatJson_internal(internal_options.prefix, json);
    }
-}
+};
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "jsonflatter",
-  "version": "0.0.1",
+  "name": "@lanetix/jsonflatter",
+  "version": "0.0.2",
   "dependencies": {
     "underscore": "1.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanetix/jsonflatter",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "dependencies": {
     "underscore": "1.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lanetix/jsonflatter",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "dependencies": {
     "underscore": "1.6.0"
   },

--- a/test/test_flatter.js
+++ b/test/test_flatter.js
@@ -3,6 +3,7 @@ var jsonFlatter = require('../jsonflatter.js'),
 
 describe('Json Flatter test', function () {
    it('should flatten given json', function (done) {
+      var now = new Date();
       var json = {
          a:1,
          b:{
@@ -13,7 +14,8 @@ describe('Json Flatter test', function () {
             a:[1,2,3],
             b:{},
             c:['',null, undefined, true]
-         }
+         },
+         d: now
       };
       var expected = {
          'a': 1,
@@ -25,7 +27,8 @@ describe('Json Flatter test', function () {
          'c#c#0': '',
          'c#c#1': null,
          'c#c#2': undefined,
-         'c#c#3': true
+         'c#c#3': true,
+         'd': now
       };
       var rst1, rst2={};
       rst1 = jsonFlatter.flatJson(json, {


### PR DESCRIPTION
In the current version of **jsonFlatter**, any values that are a JavaScript `Date` are stripped out of the final JSON. This patch adds support for those dates.
